### PR TITLE
Upgrade deprecated set-output command

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 10

--- a/.github/workflows/lambda-shared-build.yaml
+++ b/.github/workflows/lambda-shared-build.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Use Node.js Current
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
         cache: 'npm'
@@ -61,9 +61,9 @@ jobs:
     - name: Lint code
       run: npm run lint
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Log in to GitHub Docker Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
     - name: Build And Push Image with suffix label
       if: inputs.docker_image_version_suffix_label != ''
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: ${{ inputs.docker_push }}
         context: .
@@ -93,7 +93,7 @@ jobs:
           org.opencontainers.image.source=https://github.com/${{ github.repository }}
     - name: Build And Push Image
       if: inputs.docker_image_version_suffix_label == ''
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: ${{ inputs.docker_push }}
         context: .
@@ -109,6 +109,5 @@ jobs:
     - name: Set output variables
       id: setOutput
       run: |
-        echo "::set-output name=package_version::${{ env.PACKAGE_VERSION }}"
-        echo "::set-output name=build_date::${{ env.BUILD_DATE }}"
-  
+        echo "package_version=${{ env.PACKAGE_VERSION }}" >> $GITHUB_OUTPUT
+        echo "build_date=${{ env.BUILD_DATE }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
• Upgrade versions of actions which were using set-output and set-state
• Configure dependabot to warn about upgrading actions in the future
• Updated our own set-output usage
